### PR TITLE
Update Waves.tex

### DIFF
--- a/year-1/Physics-1B/Waves.tex
+++ b/year-1/Physics-1B/Waves.tex
@@ -9,7 +9,7 @@ If we measure a value \(x\) then we call the uncertainty in this measurement \(\
 For a multivariable function such as \(w=f(x,y,z)\) where \(x,y\) and \(z\) have uncorrelated errors (errors that don't effect eachother) we write the contribution of \(x\) to the error of \(w\) as \(\delta w_x\). It is calculated as:
 \[\delta w_x=\pd wx\biggr|_x\delta x\]
 
-We combine the errors by adding errors in quadrature. That is each error is squared and then added together and squarerooted:
+We combine the errors by adding errors in quadrature. That is each error is squared and then added together and square rooted:
 \[\delta w=\sqrt{\delta w_x^2+\delta w_y^2+\delta w_z^2}\]
 
 \part{Waves}


### PR DESCRIPTION
now ```squarerooted``` reads ```square rooted```
Fixes: #8 